### PR TITLE
Add preferences form to resume analyzer

### DIFF
--- a/front.py
+++ b/front.py
@@ -10,6 +10,47 @@ st.write("Faça o upload de seus currículos em DOCX ou PDF")
 # Botão de upload de arquivo
 uploaded_file = st.file_uploader("Escolha um arquivo .zip", type=["zip"])
 
+# Formulário para coletar preferências adicionais da análise
+with st.form("resume_preferences"):
+    anos_experiencia = st.number_input(
+        "Anos de experiência",
+        min_value=0,
+        step=1,
+        value=0,
+        help="Informe quantos anos de experiência profissional você possui.",
+    )
+    tempo_minimo_experiencias = st.number_input(
+        "Tempo Mínimo entre Experiências (meses)",
+        min_value=0,
+        step=1,
+        value=0,
+        help="Tempo mínimo desejado entre cada experiência profissional listada.",
+    )
+    possui_trabalho_voluntario = st.checkbox("Possui Trabalho Voluntario")
+    preferencias_enviadas = st.form_submit_button("Aplicar Preferências")
+
+if preferencias_enviadas:
+    st.session_state["resume_preferences"] = {
+        "anos_experiencia": anos_experiencia,
+        "tempo_minimo_experiencias": tempo_minimo_experiencias,
+        "possui_trabalho_voluntario": possui_trabalho_voluntario,
+    }
+    st.success(
+        "Preferências salvas: {} anos de experiência, mínimo de {} meses entre experiências, {} trabalho voluntário.".format(
+            anos_experiencia,
+            tempo_minimo_experiencias,
+            "com" if possui_trabalho_voluntario else "sem",
+        )
+    )
+elif "resume_preferences" in st.session_state:
+    st.info(
+        "Preferências atuais: {} anos de experiência, mínimo de {} meses entre experiências, {} trabalho voluntário.".format(
+            st.session_state["resume_preferences"]["anos_experiencia"],
+            st.session_state["resume_preferences"]["tempo_minimo_experiencias"],
+            "com" if st.session_state["resume_preferences"]["possui_trabalho_voluntario"] else "sem",
+        )
+    )
+
 # Verificar se um arquivo foi carregado
 if uploaded_file is not None:
     st.success(f"Arquivo '{uploaded_file.name}' carregado com sucesso!")


### PR DESCRIPTION
## Summary
- add a Streamlit form to collect experience, gap, and volunteer preference inputs
- persist submitted preferences in session state and display confirmation messaging

## Testing
- ❌ `streamlit run front.py --server.headless true --server.port 8501` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b36bd9588329a06be96517427b6a